### PR TITLE
Add an autoresizing mask to each subview

### DIFF
--- a/MDPSplitView.m
+++ b/MDPSplitView.m
@@ -133,6 +133,12 @@ static MDPSplitView *CommonInit(MDPSplitView *self)
         return [super defaultAnimationForKey:key];
 }
 
+- (void)didAddSubview:(NSView *)subview {
+	subview.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	subview.translatesAutoresizingMaskIntoConstraints = YES;
+	[super didAddSubview:subview];
+}
+
 
 #pragma mark - API
 


### PR DESCRIPTION
This fixes the introduction of 0-width/-height `NSAutoresizingMaskLayoutConstraint`s.